### PR TITLE
Replace clldutils.dsv with csvw.dsv

### DIFF
--- a/src/pyconcepticon/util.py
+++ b/src/pyconcepticon/util.py
@@ -5,7 +5,7 @@ from operator import attrgetter
 from pathlib import Path
 
 from clldutils import jsonlib
-from clldutils import dsv
+from csvw import dsv
 
 import pyconcepticon
 


### PR DESCRIPTION
Fixes #12

I checked that `csvw` is already listed as dependency in
https://github.com/concepticon/pyconcepticon/blob/70120b13ba7ba32de01b4fb8a2299b22de4c8d78/setup.py#L29