### PR TITLE
Small refactorings

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/src/pyconcepticon/glosses.py
+++ b/src/pyconcepticon/glosses.py
@@ -3,8 +3,7 @@ Module provides functions for the handling of concept glosses in linguistic data
 """
 import re
 from collections import defaultdict
-
-from clldutils.misc import lazyproperty
+from functools import cached_property
 
 import attr
 
@@ -35,7 +34,7 @@ class Gloss(object):
 
     frequency = attr.ib(default=0)
 
-    @lazyproperty
+    @cached_property
     def tokens(self):
         return ' '.join(s for s in self.gloss.split() if s not in ['or'])
 

--- a/src/pyconcepticon/models.py
+++ b/src/pyconcepticon/models.py
@@ -1,16 +1,16 @@
-import re
-import pathlib
-import operator
-import warnings
 import collections
+import operator
+import pathlib
+import re
+import warnings
+from functools import cached_property
 
 import attr
-from clldutils.apilib import DataObject
-from clldutils.misc import lazyproperty
-from clldutils.jsonlib import load
 import csvw
-from csvw.metadata import TableGroup, Link
+from clldutils.apilib import DataObject
+from clldutils.jsonlib import load
 from csvw.dsv import reader
+from csvw.metadata import TableGroup, Link
 
 from pyconcepticon.util import split, split_ids, read_dicts, to_dict
 
@@ -95,11 +95,11 @@ class Conceptset(Bag):
         if self._api and self.replacement_id:
             return self._api.conceptsets[self.replacement_id]
 
-    @lazyproperty
+    @cached_property
     def relations(self):
         return self._api.relations.get(self.id, {}) if self._api else {}
 
-    @lazyproperty
+    @cached_property
     def concepts(self):
         res = []
         if self._api:
@@ -191,7 +191,7 @@ class Concept(Bag):
     def label(self):
         return self.gloss or self.english
 
-    @lazyproperty
+    @cached_property
     def cols(self):
         return Concept.public_fields() + list(self.attributes.keys())
 
@@ -215,7 +215,7 @@ class Conceptlist(Bag):
     alias = attr.ib(converter=lambda s: [] if s is None else split(s))
     local = attr.ib(default=False)
 
-    @lazyproperty
+    @cached_property
     def tg(self):
         md = self.path.parent.joinpath(self.path.name + MD_SUFFIX)
         if not md.exists():
@@ -239,7 +239,7 @@ class Conceptlist(Bag):
         tg.tables[0].url = Link('{0}.tsv'.format(self.id))
         return tg
 
-    @lazyproperty
+    @cached_property
     def metadata(self):
         return self.tg.tables[0]
 
@@ -249,16 +249,16 @@ class Conceptlist(Bag):
             return self._api
         return self._api.data_path('conceptlists', self.id + '.tsv')
 
-    @lazyproperty
+    @cached_property
     def cols_in_list(self):
         return list(next(reader(self.path, dicts=True, delimiter='\t')).keys())
 
-    @lazyproperty
+    @cached_property
     def attributes(self):
         return [c.name for c in self.metadata.tableSchema.columns
                 if c.name.lower() not in Concept.public_fields()]
 
-    @lazyproperty
+    @cached_property
     def concepts(self):
         res = []
         if self.path.exists():

--- a/src/pyconcepticon/models.py
+++ b/src/pyconcepticon/models.py
@@ -160,10 +160,9 @@ class ConceptRelations(dict):
         """
         Search for concept relations of a given concept.
 
-        :param search_depth: maximal depth of search
-        :param relation: the concept relation to be searched (currently only
-            "broader" and "narrower".
-
+        :param concept: CONCEPTICON_ID for which to perform the search
+        :param max_degree_of_separation: maximal depth of search
+        :param relation: the concept relation to be searched (currently only "broader" and "narrower")
         """
         queue = collections.deque([(concept, 0)])
         while queue:
@@ -172,7 +171,7 @@ class ConceptRelations(dict):
             for target, rels in self.get(current_concept, {}).items():
                 if (relation in rels or relation == rels) and depth <= max_degree_of_separation:
                     queue.append((target, depth))
-                    yield (target, depth)
+                    yield target, depth
 
 
 @attr.s


### PR DESCRIPTION
- since Python 3.7 is EOL, began replacing `@lazyproperty` with `@functools.cached_property`
- small doc fix